### PR TITLE
fix: replace hardcoded IPs with placeholders in documentation

### DIFF
--- a/docs/ha-addon-mvp.md
+++ b/docs/ha-addon-mvp.md
@@ -122,12 +122,12 @@ Option B — Manual:
 ```bash
 # Copy token files to HAOS
 cat /tmp/garmin-tokens/oauth1_token.json | \
-  ssh -p 22222 hassio@192.168.1.176 "cat > /tmp/oauth1_token.json"
+  ssh -p 22222 hassio@<YOUR_HA_IP> "cat > /tmp/oauth1_token.json"
 cat /tmp/garmin-tokens/oauth2_token.json | \
-  ssh -p 22222 hassio@192.168.1.176 "cat > /tmp/oauth2_token.json"
+  ssh -p 22222 hassio@<YOUR_HA_IP> "cat > /tmp/oauth2_token.json"
 
 # Import via addon API (from HAOS SSH)
-ssh -p 22222 hassio@192.168.1.176
+ssh -p 22222 hassio@<YOUR_HA_IP>
 curl -X POST -H 'Content-Type: application/json' \
   -d "$(python3 -c 'import json; o1=json.load(open("/tmp/oauth1_token.json")); o2=json.load(open("/tmp/oauth2_token.json")); print(json.dumps({"oauth1_token":o1,"oauth2_token":o2}))')" \
   'http://ecfdb23d-garmincoach:3000/api/garmin/auth-import'

--- a/garmin-COMPLETE-ARCHITECTURE.md
+++ b/garmin-COMPLETE-ARCHITECTURE.md
@@ -24,7 +24,7 @@ You have **THREE separate** Garmin-related components:
 ### 2. Grafana HAOS Addon ✅
 **Addon ID**: `a0d7b954_grafana`
 **Access URLs**:
-- Direct: http://192.168.1.176:3000
+- Direct: http://<YOUR_HA_IP>:3000
 - Ingress: https://haos.askb.dev/a0d7b954_grafana
 
 **What it does**:
@@ -36,7 +36,7 @@ You have **THREE separate** Garmin-related components:
 **Type**: HAOS addon (installed separately from HACS integration)
 
 ### 3. InfluxDB HAOS Addon ✅
-**Location**: http://192.168.1.176:8086
+**Location**: http://<YOUR_HA_IP>:8086
 **Database**: `garmin`
 
 **What it does**:
@@ -70,7 +70,7 @@ Garmin Connect API
     ↓ (laptop script with tokens)
 Python sync.py
     ↓ (HTTP POST)
-InfluxDB on HAOS (192.168.1.176:8086)
+InfluxDB on HAOS (<YOUR_HA_IP>:8086)
     ↓ (InfluxQL queries)
 Grafana Dashboard (garmin-stats)
     ↓
@@ -87,7 +87,7 @@ Visualization
 - **Option C**: Something else?
 
 **To find out**, check the dashboard:
-1. Open: http://192.168.1.176:3000/d/feiibsx498gsgb/garmin-stats
+1. Open: http://<YOUR_HA_IP>:3000/d/feiibsx498gsgb/garmin-stats
 2. Click any panel → **Edit**
 3. Look at **Data source** dropdown at top
 4. What does it say?


### PR DESCRIPTION
Replaces all `192.168.1.176` references with `<YOUR_HA_IP>` placeholders in docs.